### PR TITLE
chore(deps): pin node-fetch to 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     },
     "resolutions": {
         "mem": "4.3.0",
+        "node-fetch": "2.6.1",
         "object-path": "0.11.5",
         "yargs-parser": "13.1.2"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9963,12 +9963,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
-
-node-fetch@2.6.1, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.1:
+node-fetch@2.6.0, node-fetch@2.6.1, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
Snyk reported an issue with node-fetch 2.6.0 for a potential denial of service attack. This is fixed
in 2.6.1